### PR TITLE
ci: adding script to update dnsimple

### DIFF
--- a/.github/workflows/dns-update.yml
+++ b/.github/workflows/dns-update.yml
@@ -16,4 +16,4 @@ jobs:
     - run: npm i
     - run: ./dnsimple-update-script.js
       env:
-        DNSIMPLE_ACCESS_TOKEN: ${{ secrets.DNSIMPLE_ACCESS_TOKEN }}
+        DNSIMPLE_ACCESS_TOKEN: ${{ secrets.DNSIMPLE_TOKEN }}

--- a/.github/workflows/dns-update.yml
+++ b/.github/workflows/dns-update.yml
@@ -1,0 +1,19 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  update-dns:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 16
+    - run: npm i
+    - run: ./dnsimple-update-script.js
+      env:
+        DNSIMPLE_ACCESS_TOKEN: ${{ secrets.DNSIMPLE_ACCESS_TOKEN }}

--- a/dnsimple-update-script.js
+++ b/dnsimple-update-script.js
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+//
+// Script to update the dns TXT entries of "dnslink.dev" subdomains needed for the tests
+// To use this script you need to set the following environment variables:
+//   DNSIMPLE_ACCESS_TOKEN: <your access token>
+//   DNSIMPLE_BASE_URL (optional): set to https://api.sandbox.dnsimple.com if you would like to use the sandbox
+//
+const dnsimple = require('dnsimple')
+const { tests } = require('.')
+const pmapImport = import('p-map')
+const util = require('util')
+
+;(async function main () {
+  const credentials = {
+    baseUrl: process.env.DNSIMPLE_BASE_URL,
+    accessToken: process.env.DNSIMPLE_ACCESS_TOKEN
+  }
+  let client
+  try {
+    client = dnsimple(credentials)
+    await client.identity.whoami()
+  } catch (e) {
+    if (e.message === 'Authentication failed') {
+      throw new Error(`Authentication failed, did you set the DNSIMPLE_BASE_URL and DNSIMPLE_ACCESS_TOKEN environment variables?\n${util.inspect(credentials)}`)
+    }
+    throw e
+  }
+
+  const domain = 'dnslink.dev'
+  const suffix = `.${domain}`
+
+  const { default: pmap } = await pmapImport
+  const { zone, account } = await findAccountForDomain(client, domain)
+
+  const txtEntries = txtEntriesForTests(tests, suffix)
+  const knownSubDomains = new Set(Object.keys(txtEntries))
+  const operations = (await client.zones.allZoneRecords(account.id, zone.id, { type: 'TXT' }))
+    .filter(record => knownSubDomains.has(record.name))
+    .map(record => {
+      const perDomain = txtEntries[record.name]
+      const content = record.content.trim()
+      const log = `${record.name}${suffix} TXT ${record.content}`
+      if (perDomain.has(content)) {
+        perDomain.delete(content)
+        return () => console.log(`~ ${log}`)
+      }
+      return async () => {
+        try {
+          await client.zones.deleteZoneRecord(account.id, zone.id, record.id)
+          console.log(`- ${log}`)
+        } catch (error) {
+          renderError(`e- Error while removing: ${log}`, error)
+        }
+      }
+    })
+
+  for (const [name, domainEntries] of Object.entries(txtEntries)) {
+    for (const content of domainEntries) {
+      const log = `${name}${suffix} TXT ${content}`
+      const entry = { name, type: 'TXT', content }
+      operations.push(async () => {
+        try {
+          await client.zones.createZoneRecord(account.id, zone.id, entry)
+          console.log(`+ ${log}`)
+        } catch (error) {
+          renderError(`e+ Error while adding: ${log}`, error)
+        }
+      })
+    }
+  }
+  await pmap(operations, op => op(), { concurrency: 10 })
+})().catch(error => {
+  console.error(error)
+  process.exit(1)
+})
+
+function txtEntriesForTests (tests, suffix) {
+  const txtEntries = {}
+  for (const test of Object.values(tests)) {
+    const raw = test.dns(test.targetDomain)
+    for (const key in raw) {
+      if (key.endsWith(suffix)) {
+        const subDomain = key.substr(0, key.length - suffix.length)
+        txtEntries[subDomain] = new Set(raw[key].map(entry => entry.trim()))
+      }
+    }
+  }
+  return txtEntries
+}
+
+function renderError (message, error) {
+  const errorString = error.stack ? error.stack : util.inspect(error, true, Infinity)
+  console.log(`${message}\n    ${errorString.split('\n').join('\n    ')}`)
+}
+
+// Get the list of accounts available to this token.
+async function findAccounts (client) {
+  const res = await client.accounts.listAccounts()
+  return res.data
+}
+
+async function findAccountForDomain (client, domain) {
+  const accounts = await findAccounts(client)
+  for (const account of accounts) {
+    const zone = await findZoneOrNull(client, account.id, domain)
+    if (zone) {
+      return {
+        zone,
+        account
+      }
+    }
+  }
+  throw new Error(`Failed to find zone record for ${domain} with the token provided. Did you use the wrong token?`)
+}
+
+// Try and fetch a zone record for the domain.
+async function findZoneOrNull (client, accountId, domain) {
+  try {
+    const zone = await client.zones.getZone(accountId, domain)
+    return zone.data
+  } catch (err) {
+    if (err.description === 'Not found') {
+      return null
+    }
+    throw err
+  }
+}

--- a/package.json
+++ b/package.json
@@ -38,7 +38,9 @@
     "which": "^2.0.2"
   },
   "devDependencies": {
+    "dnsimple": "^5.0.0",
     "dtslint": "^4.1.0",
+    "p-map": "^5.0.0",
     "standard": "^16.0.3",
     "typescript": "^4.3.2"
   }


### PR DESCRIPTION
This PR adds a script that uses a `DNSIMPLE_ACCESS_TOKEN` environment variable to update the TXT entries of all needed subdomains using the `dnsimple` API.

Should be okay to merge after the Secret is set.

Closes #2